### PR TITLE
Introduce variations in analysis results

### DIFF
--- a/src/Analysis/IAnalysis.ts
+++ b/src/Analysis/IAnalysis.ts
@@ -1,4 +1,5 @@
 import { IScore } from "./IScore";
+import { IVariation } from "./IVariation";
 
 /**
  * @interface IAnalysis
@@ -16,4 +17,5 @@ export interface IAnalysis {
     nps: number | null;
     moves: string[] | null;
     score: IScore | null;
+    variations: IVariation[] | null;
 }

--- a/src/Analysis/IVariation.ts
+++ b/src/Analysis/IVariation.ts
@@ -1,0 +1,11 @@
+/**
+ * @interface IVariations
+ * @module IVariations
+ */
+export interface IVariation {
+    depth: number;
+    score: number;
+    scoreType: string;
+    timeMs: number;
+    moves: string;
+}

--- a/src/Engine/Engine.ts
+++ b/src/Engine/Engine.ts
@@ -110,6 +110,11 @@ export class Engine {
                 };
                 callback(result);
             }
+
+            /**
+             * Clean the multiPv cache
+             */
+            this.handler.reset();
         });
     }
 

--- a/src/Uci/Parser.ts
+++ b/src/Uci/Parser.ts
@@ -75,7 +75,7 @@ export class Parser {
          *
          * info depth 2 seldepth 2 multipv 3 score cp 121 nodes 402 nps 402000 tbhits 0 time 1 pv a2a3 c5b3
          */
-        const regex = /info.*\sdepth\s([0-9]+).*multipv\s([0-9]+).*score\s(.*)\s([0-9]+).*nodes.*time\s([0-9]+).*pv\s([a-h1-8\s]+)$/
+        const regex = /info.*\sdepth\s([0-9]+).*multipv\s([0-9]+).*score\s(.*)\s(-?[0-9]+).*nodes.*time\s([0-9]+).*pv\s([a-h1-8\s]+)$/
         const matches = output.trim().match(regex)
 
         if (matches !== null) {

--- a/src/Uci/Parser.ts
+++ b/src/Uci/Parser.ts
@@ -1,4 +1,5 @@
 import { IScore } from "../Analysis/IScore";
+import { IVariation } from "../Analysis/IVariation";
 import { IEngineOption } from "../Engine/IEngineOption";
 import { IEngineId } from "src/Engine/IEngineId";
 
@@ -49,6 +50,58 @@ export class Parser {
         }
 
         return null;
+    }
+
+    /**
+     * Engines give us multiple variations and their scores, and we want to
+     * process and return all those. This method does that.
+     *
+     * Because this is called with single lines as input (not the entire
+     * UCI output), we need to compare it against previous lines to keep just the
+     * latest depth for a given MultiPv.
+     *
+     * @public
+     * @static
+     * @method
+     * @param {string} output
+     * @param {Record<number, IVariation>} candidates: this will inject the
+     *        cached from previous analysis iterations.
+     * @return {IVariation[]|null}
+     */
+    public static parsePrincipalVariations(output: string, candidates: Record<number, IVariation> = {}): Record<number, IVariation> {
+        candidates = Object.assign({}, candidates)
+        /**
+         * This is an example of output line:
+         *
+         * info depth 2 seldepth 2 multipv 3 score cp 121 nodes 402 nps 402000 tbhits 0 time 1 pv a2a3 c5b3
+         */
+        const regex = /info.*\sdepth\s([0-9]+).*multipv\s([0-9]+).*score\s(.*)\s([0-9]+).*nodes.*time\s([0-9]+).*pv\s([a-h1-8\s]+)$/
+        const matches = output.trim().match(regex)
+
+        if (matches !== null) {
+            let depth: number = parseInt(matches[1])
+            let pv: number = parseInt(matches[2])
+            let scoreType: string = matches[3]
+            let score: number = parseInt(matches[4])
+            let time: number = parseInt(matches[5])
+            let moves: string = matches[6]
+
+            /**
+             * If for whatever reason we get MultiPv lines out of order, let's
+             * keep the one with highest depth.
+             */
+            if (!candidates[pv] || candidates[pv].depth < depth) {
+                candidates[pv] = {
+                    depth: depth,
+                    score: score,
+                    scoreType: scoreType,
+                    timeMs: time,
+                    moves: moves
+                }
+            }
+        }
+
+        return candidates
     }
 
     /**

--- a/test/integration/analysis.ts
+++ b/test/integration/analysis.ts
@@ -4,6 +4,10 @@ import { Engine } from "../../src/Engine/Engine";
 import { IResult } from "../../src/Analysis/IResult";
 import { enginePath } from "./util";
 
+const position = {
+  fen: "r1bqkb1r/5ppp/p2ppn2/1pn5/3NP3/1BN5/PPP2PPP/R1BQR1K1 w kq - 4 10",
+};
+
 describe("Analysis", (): void => {
     before(function() {
         if (!enginePath) this.skip();
@@ -11,11 +15,9 @@ describe("Analysis", (): void => {
 
     it("should find the best move at the requested depth", (done: Function): void => {
         const engine = new Engine(enginePath);
-        const position = {
-            fen: "r1bqkb1r/5ppp/p2ppn2/1pn5/3NP3/1BN5/PPP2PPP/R1BQR1K1 w kq - 4 10",
-        };
         const resolution = { depth: 15 };
 
+        engine.setOptions({"MultiPv": "1"})
         engine.analyzePosition(
             position,
             resolution,
@@ -24,6 +26,35 @@ describe("Analysis", (): void => {
                 expect(result.position.fen).to.eq(position.fen);
                 expect(result.analysis.moves![0]).to.eq("b3d5");
                 expect(result.analysis.score!.value).to.be.greaterThan(100);
+                done();
+            }
+        );
+    });
+
+    it("should find the best move at the requested MultiPv", (done: Function): void => {
+        const engine = new Engine(enginePath);
+        const resolution = { depth: 3 };
+
+        engine.setOptions({"MultiPv": "3"})
+        engine.analyzePosition(
+            position,
+            resolution,
+            (result: IResult): void => {
+                expect(result.bestMove).to.eq("d4c6");
+                expect(result.position.fen).to.eq(position.fen);
+                expect(result.analysis.score!.value).to.be.greaterThan(100);
+
+                const variations: string[] = [
+                  result.analysis.variations![0].moves!,
+                  result.analysis.variations![1].moves!,
+                  result.analysis.variations![2].moves!
+                ]
+
+                expect(variations).to.have.members([
+                  "d4c6 c5b3 c6d8",
+                  "c1g5 c5b3 a2b3",
+                  "c1d2 c5b3 a2b3"
+                ]);
                 done();
             }
         );

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -100,13 +100,13 @@ describe("Parser", (): void => {
 
         it("parses MultiPv and prioritizes greater depth", (): void => {
             // Difference here is different multipv
-            const output = "info depth 7 seldepth 24 multipv 2 score cp 20 nodes 809947 nps 2060933 tbhits 0 time 200 pv f2f3 c8d7 c1e3 f8e7 a2a3 e8g8 b3a2"
+            const output = "info depth 7 seldepth 24 multipv 2 score cp -20 nodes 809947 nps 2060933 tbhits 0 time 200 pv f2f3 c8d7 c1e3 f8e7 a2a3 e8g8 b3a2"
 
             const result = Parser.parsePrincipalVariations(output, variations);
             expect(result).to.deep.eq({
                 2: {
                     "depth": 7,
-                    "score": 20,
+                    "score": -20,
                     "scoreType": "cp",
                     "timeMs": 200,
                     "moves":  "f2f3 c8d7 c1e3 f8e7 a2a3 e8g8 b3a2"

--- a/test/parser.ts
+++ b/test/parser.ts
@@ -1,6 +1,7 @@
 import "mocha";
 import { expect } from "chai";
 import { Parser } from "../src";
+import { IVariation } from "../src/Analysis/IVariation";
 
 describe("Parser", (): void => {
     describe("parseBestMove", () => {
@@ -67,6 +68,58 @@ describe("Parser", (): void => {
                 max: null,
                 min: null,
             });
+        });
+    });
+
+    describe("parsePrincipalVariations", () => {
+        const variations: Record<number, IVariation> = {
+            "2": {
+                "depth": 5,
+                "score": 10,
+                "scoreType": "cp",
+                "timeMs": 100,
+                "moves": "original"
+            }
+        }
+
+        it("parses MultiPv and adds new variations", (): void => {
+            const output = "info depth 7 seldepth 24 multipv 3 score cp 20 nodes 809947 nps 2060933 tbhits 0 time 200 pv f2f3 c8d7 c1e3 f8e7 a2a3 e8g8 b3a2"
+
+            const result = Parser.parsePrincipalVariations(output, variations);
+            expect(result).to.deep.eq({
+                ...variations,
+                "3": {
+                    "depth": 7,
+                    "score": 20,
+                    "scoreType": "cp",
+                    "timeMs": 200,
+                    "moves":  "f2f3 c8d7 c1e3 f8e7 a2a3 e8g8 b3a2"
+                }
+            });
+        });
+
+        it("parses MultiPv and prioritizes greater depth", (): void => {
+            // Difference here is different multipv
+            const output = "info depth 7 seldepth 24 multipv 2 score cp 20 nodes 809947 nps 2060933 tbhits 0 time 200 pv f2f3 c8d7 c1e3 f8e7 a2a3 e8g8 b3a2"
+
+            const result = Parser.parsePrincipalVariations(output, variations);
+            expect(result).to.deep.eq({
+                2: {
+                    "depth": 7,
+                    "score": 20,
+                    "scoreType": "cp",
+                    "timeMs": 200,
+                    "moves":  "f2f3 c8d7 c1e3 f8e7 a2a3 e8g8 b3a2"
+                }
+            });
+        });
+
+        it("parses MultiPv and keeps depth from cache", (): void => {
+            // Difference here is output has same multipv, but lower depth
+            const output = "info depth 2 seldepth 24 multipv 2 score cp 20 nodes 809947 nps 2060933 tbhits 0 time 200 pv f2f3 c8d7 c1e3 f8e7 a2a3 e8g8 b3a2"
+
+            const result = Parser.parsePrincipalVariations(output, variations);
+            expect(result).to.deep.eq({ ...variations });
         });
     });
 });


### PR DESCRIPTION
Today's results include one best move, one score and that's it, regardless of
what MultiPv is configured. This makes it less than ideal for external software
to build on more complex features.

This changes that while keeping backwards compatibility. Now, besides best move
and score, there's a new `variations` key in the analysis results containing an
array of the multiple principal variations (MultiPv), each including a variation
with N depth moves, as well as score, time for processing and score type.

The challenge behind this change was that each line in the UCI multiline output
is processed separatelly, and no state is kept in between them. In order to make
it possible to return the correct MultiPv, the one with the greatest depth, I
introduced an analysis cache in the `Handler` object, that is inject into the
new output analysis function, adding state in between output lines processing.
When analysis is complete, `handler.reset()` takes care of cleaning that cache
for subsequent calls to take place.

Additionally, this cache is duplicated to avoid leaking state in between tests and
instances. More specifically, `parsePrincipalVariations` runs
`candidates = Object.assign({}, candidates)` to ensure this method doesn't
modify the reference being passed in. We use `Object.assign` here because we
don't care about deep cloning for now. Shallow cloning should work.